### PR TITLE
feat (exclude): Add field to exclude a lab from the main page listing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,8 @@ revisionDate: '2020-03-16'
 labels:
   - data
 
+excludeFromListing: true
+
 author:
   name: Asa Schachar
   headshot: '/assets/authors/asa.jpeg'
@@ -53,4 +55,10 @@ seo:
 ```
 5. Submit your changes as a pull request to get reviewed and merged by the Optimizely team.
 
-6. Profit 🎉
+6. Once the pull request is merged, your lab will be available at www.optimizely.com/labs/new-awesome-tutorial
+
+7. Tweak your content to make sure everything looks as you want it to.
+
+8. Once it is ready to be featured on the main page, make a separate pull request to set `excludeFromListing` to `false` in `metadata.md` which will publish the lab on the main optimizely.com/labs page.
+
+9. Profit 🎉

--- a/labs/banner-editor-extension/metadata.md
+++ b/labs/banner-editor-extension/metadata.md
@@ -6,6 +6,8 @@ labels:
   - web
   - editor extension
 
+excludeFromListing: false
+
 author:
   name: Asa Schachar
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/asaschachar.png

--- a/labs/computing-experiment-subjects/metadata.md
+++ b/labs/computing-experiment-subjects/metadata.md
@@ -7,6 +7,8 @@ labels:
   - data
   - analysis
 
+excludeFromListing: false
+
 author:
   name: Pete Koomen
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/petekoomen.png

--- a/labs/contentful-optimizely-integration/metadata.md
+++ b/labs/contentful-optimizely-integration/metadata.md
@@ -7,6 +7,8 @@ labels:
   - full stack
   - cms
 
+excludeFromListing: false
+
 author:
   name: Contentful Team
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/contentful-icon.svg

--- a/labs/contentsquare-integration-full-stack/metadata.md
+++ b/labs/contentsquare-integration-full-stack/metadata.md
@@ -7,6 +7,8 @@ labels:
   - full stack
   - analytics
 
+excludeFromListing: false
+
 author:
   name: David Sertillange
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/davidsertillange.png

--- a/labs/contentsquare-integration-web/metadata.md
+++ b/labs/contentsquare-integration-web/metadata.md
@@ -7,6 +7,8 @@ labels:
   - web
   - analytics
 
+excludeFromListing: false
+
 author:
   name: David Sertillange
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/davidsertillange.png

--- a/labs/feature-flags-python-flask/metadata.md
+++ b/labs/feature-flags-python-flask/metadata.md
@@ -8,6 +8,8 @@ labels:
   - flask
   - feature flags
 
+excludeFromListing: false
+
 author:
   name: Asa Schachar
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/asaschachar.png

--- a/labs/feature-flags-ruby-sinatra/metadata.md
+++ b/labs/feature-flags-ruby-sinatra/metadata.md
@@ -8,6 +8,8 @@ labels:
   - sinatra
   - feature flags
 
+excludeFromListing: false
+
 author:
   name: Asa Schachar
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/asaschachar.png

--- a/labs/query-enriched-event-data-with-spark/metadata.md
+++ b/labs/query-enriched-event-data-with-spark/metadata.md
@@ -7,6 +7,8 @@ labels:
   - data
   - analysis
 
+excludeFromListing: false
+
 author:
   name: Pete Koomen
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/petekoomen.png

--- a/labs/segment-full-stack-destination/metadata.md
+++ b/labs/segment-full-stack-destination/metadata.md
@@ -7,6 +7,8 @@ labels:
   - full stack
   - analytics
 
+excludeFromListing: false
+
 author:
   name: Segment Team
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/segment-icon.svg

--- a/labs/sequential-events-targeting/metadata.md
+++ b/labs/sequential-events-targeting/metadata.md
@@ -7,6 +7,8 @@ labels:
   - personalisation
   - events
 
+excludeFromListing: false
+
 author:
   name: Thomas Clayson
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/thomasclayson.jpg

--- a/labs/static-site-feature-flags/metadata.md
+++ b/labs/static-site-feature-flags/metadata.md
@@ -7,6 +7,8 @@ labels:
   - static site
   - feature flags
 
+excludeFromListing: false
+
 author:
   name: Asa Schachar
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/asaschachar.png

--- a/labs/web-full-stack-event-integration/metadata.md
+++ b/labs/web-full-stack-event-integration/metadata.md
@@ -7,6 +7,8 @@ labels:
   - web
   - data
 
+excludeFromListing: false
+
 author:
   name: David Sertillange
   headshot: https://raw.githubusercontent.com/optimizely/labs/master/assets/author-headshots/davidsertillange.png

--- a/utils/publish.py
+++ b/utils/publish.py
@@ -183,6 +183,9 @@ def upsert_lab_to_contentful(slug, lab_info):
       'seo': {
         'en-US': lab_info['seo'],
       },
+      'excludeFromListing': {
+        'en-US': lab_info['excludeFromListing']
+      }
     }
   }
 


### PR DESCRIPTION
Add a field which can be used to exclude a lab from the main labs listing page. This will enable a workflow to work on a 'draft' lab before featuring it on the homepage.