### PR TITLE
Update Contentsquare case

### DIFF
--- a/labs/contentsquare-integration-full-stack/README.md
+++ b/labs/contentsquare-integration-full-stack/README.md
@@ -1,14 +1,14 @@
-# ContentSquare Integration
+# Contentsquare Integration
 
-Hello! This integration allows you to send data from Optimizely Full Stack into ContentSquare.
+Hello! This integration allows you to send data from Optimizely Full Stack into Contentsquare.
 
 ## Pre-requisites
 
-You need a ContentSquare and Optimizely account. 
+You need a Contentsquare and Optimizely account. 
 
 ### Installation
 
-This integration uses [Optimizely's Notification Listeners](https://docs.developers.optimizely.com/full-stack/docs/set-up-notification-listener-swift) to retrieve the Optimizely experiment and variation data and send them to ContentSquare. 
+This integration uses [Optimizely's Notification Listeners](https://docs.developers.optimizely.com/full-stack/docs/set-up-notification-listener-swift) to retrieve the Optimizely experiment and variation data and send them to Contentsquare. 
 
 This integration is built to be used with Optimizely's Full Stack client-side SDKs (Javascript, React, React Native). Server-side Optimizely Full Stack SDKs are ***not*** supported by this integration. 
 
@@ -47,10 +47,10 @@ optimizelyClient.notificationCenter.addNotificationListener(
 ```
 - That's it! 
 
-On every experiment activation (method `activate()` or `isFeatureEnabled` is invoked), then an Optimizely's Notification Listener will execute, grabbing the experiment data from Optimizely and will forward them to ContentSquare. 
+On every experiment activation (method `activate()` or `isFeatureEnabled` is invoked), then an Optimizely's Notification Listener will execute, grabbing the experiment data from Optimizely and will forward them to Contentsquare. 
 ### Using the integration
 
-If everything works properly, you should see in ContentSquare a Dynamic Variable called `AB_OP_` followed by the campaign Id and experiment Id.	 
-Example: `AB_OP_18180652355_18182752153` where 18180652355 is the campaign Id and 18182752153 the experiment Id. The value of this ContentSquare dynamic variable will be the variation Ids of this experiment. 
+If everything works properly, you should see in Contentsquare a Dynamic Variable called `AB_OP_` followed by the campaign Id and experiment Id.	 
+Example: `AB_OP_18180652355_18182752153` where 18180652355 is the campaign Id and 18182752153 the experiment Id. The value of this Contentsquare dynamic variable will be the variation Ids of this experiment. 
 
-We recommend to run an A/A experiment to validate that you are able to see data coming through in ContentSquare. 
+We recommend to run an A/A experiment to validate that you are able to see data coming through in Contentsquare. 

--- a/labs/contentsquare-integration-full-stack/metadata.md
+++ b/labs/contentsquare-integration-full-stack/metadata.md
@@ -1,6 +1,6 @@
 ---
-title: ContentSquare Integration for Optimizely Full Stack
-summary: This integration allows you to send experiment and variation data from Optimizely Full Stack to ContentSquare.
+title: Contentsquare Integration for Optimizely Full Stack
+summary: This integration allows you to send experiment and variation data from Optimizely Full Stack to Contentsquare.
 revisionDate: '2020-08-19'
 labels:
   - integrations
@@ -17,8 +17,8 @@ author:
   company: Optimizely
 
 seo:
-  title: ContentSquare Integration for Optimizely Web
-  description: This integration allows you to send experiment and variation data from Optimizely Full Stack to ContentSquare.
+  title: Contentsquare Integration for Optimizely Web
+  description: This integration allows you to send experiment and variation data from Optimizely Full Stack to Contentsquare.
   ogTitle:
   ogDescription:
   ogImage:

--- a/labs/contentsquare-integration-web/README.md
+++ b/labs/contentsquare-integration-web/README.md
@@ -1,9 +1,9 @@
-# ContentSquare Integration for Optimizely Web
+# Contentsquare Integration for Optimizely Web
 
-Hello! This integration allows you to send experiment and variation data from Optimizely into ContentSquare. 
+Hello! This integration allows you to send experiment and variation data from Optimizely into Contentsquare. 
 ## Pre-requisites
 
-You need a ContentSquare and Optimizely Web account. 
+You need a Contentsquare and Optimizely Web account. 
 
 ### Installation
 
@@ -19,9 +19,9 @@ This integration is using [Optimizely's Custom Analytics feature](https://help.o
 ```json
 {
   "plugin_type": "analytics_integration",
-  "name": "ContentSquare",
+  "name": "Contentsquare",
   "form_schema": [],
-  "description": "This integration allows you to send the experiment and variation data from Optimizely Web to ContentSquare",
+  "description": "This integration allows you to send the experiment and variation data from Optimizely Web to Contentsquare",
   "options": {
     "track_layer_decision": "/*\n *Name: Optimizely CS Integration\n *Version: 2.1\n */\n(function () {\n    var tvp = \"AB_OP_\";\n\n    function sendToCS(csKey, csValue) {\n        csKey = tvp + csKey;\n\n        _uxa.push([\"trackDynamicVariable\", {\n            key: csKey,\n            value: csValue\n        }]);\n    };\n\n    function startOPIntegration(decisionString) {\n        sendToCS(decisionString.experiment, decisionString.holdback ? decisionString.variation + ' [Holdback]' : decisionString.variation);\n    }\n\n    function callback() {\n        if (!disableCallback) {\n            disableCallback = true;\n\n            var decisionString = optimizely.get('state').getDecisionObject({\n                \"campaignId\": campaignId\n            });\n\n            if (!!decisionString) {\n                startOPIntegration(decisionString);\n            }\n\n            if (window.CS_CONF) {\n                CS_CONF.integrations = CS_CONF.integrations || [];\n                CS_CONF.integrations.push(\"Optimizely\");\n            }\n        }\n    }\n\n    var disableCallback = false;\n    window._uxa = window._uxa || [];\n    _uxa.push([\"afterPageView\", callback]);\n\n})();"
   }
@@ -34,10 +34,10 @@ Before using this integration, you'll need to enable it in the [project settings
 
 Moving forward, this integration will be turned on by default for every new experiment you create in Optimizely Web. 
 
-We recommend to run an A/A experiment to validate that you are able to see data coming through in ContentSquare. 
+We recommend to run an A/A experiment to validate that you are able to see data coming through in Contentsquare. 
 
-If everything works properly, you should see in ContentSquare a Dynamic Variable called `AB_OP_` followed by the experiment name or id.	 
-Example: `AB_OP_(18180652355)` where 18180652355 is the experimentId. The value of this ContentSquare dynamic variable will be the variation Ids of this experiment. 
+If everything works properly, you should see in Contentsquare a Dynamic Variable called `AB_OP_` followed by the experiment name or id.	 
+Example: `AB_OP_(18180652355)` where 18180652355 is the experimentId. The value of this Contentsquare dynamic variable will be the variation Ids of this experiment. 
 
 ### Integration Code
 

--- a/labs/contentsquare-integration-web/metadata.md
+++ b/labs/contentsquare-integration-web/metadata.md
@@ -1,6 +1,6 @@
 ---
-title: ContentSquare Integration for Optimizely Web
-summary: This integration allows you to send experiment and variation data from Optimizely Web to ContentSquare.
+title: Contentsquare Integration for Optimizely Web
+summary: This integration allows you to send experiment and variation data from Optimizely Web to Contentsquare.
 revisionDate: '2020-08-19'
 labels:
   - integrations
@@ -17,8 +17,8 @@ author:
   company: Optimizely
 
 seo:
-  title: ContentSquare Integration for Optimizely Web
-  description: This integration allows you to send experiment and variation data from Optimizely Web to ContentSquare.
+  title: Contentsquare Integration for Optimizely Web
+  description: This integration allows you to send experiment and variation data from Optimizely Web to Contentsquare.
   ogTitle:
   ogDescription:
   ogImage:


### PR DESCRIPTION
Hello,

I work at Contentsquare, and we reference this page in our own docs: https://www.optimizely.com/developers/labs/contentsquare-integration-full-stack/

The case of Contentsquare changed over time but it is now Contentsquare, and no longer ContentSquare.